### PR TITLE
docs: updates repo names and content from UOR Framework to Emporous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # .github
 
-UOR Community organization management
+Emporous Community organization management

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -1,5 +1,5 @@
 orgs:
-  uor-community:
+  emporous-community:
     admins:
       - sabre1041
       - peribolos
@@ -10,8 +10,8 @@ orgs:
     billing_email: andy.block@gmail.com
     company: ""
     default_repository_permission: read
-    description: "Universal Object Reference Community"
-    email: "uor-framework@googlegroups.com"
+    description: "Emporous Community"
+    email: "emporous@googlegroups.com"
     has_organization_projects: true
     has_repository_projects: true
     location: ""
@@ -23,21 +23,21 @@ orgs:
         has_projects: true
       ai-model-registry:
         default_branch: main
-        description: UOR-based AI Model Registry
+        description: Emporous-based AI Model Registry
         has_projects: true
       sample-client-go:
         default_branch: main
-        description: UOR sample Go gRPC client
+        description: Emporous sample Go gRPC client
         has_projects: true
       sample-client-python:
         default_branch: main
-        description: UOR sample Python gRPC client
+        description: Emporous sample Python gRPC client
         has_projects: true
-      uor-python-index:
+      emporous-python-index:
         default_branch: main
-        description: UOR-based Python index generation and rendering
+        description: Emporous-based Python index generation and rendering
         has_projects: true
-      uor-fuse-go:
+      emporous-fuse-go:
         default_branch: main
-        description: FUSE driver to mount UOR collection to a directory
+        description: FUSE driver to mount Emporous collection to a directory
         has_projects: true

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,15 +1,15 @@
-# [UOR Framework](https://github.com/uor-framework) Community Project
+# [Emporous](https://github.com/emporous) Community Project
 
-Welcome to the UOR Framework community hub. This is a place for UOR Framework collaboration with community members and contributors.
+Welcome to the Emporous community hub. This is a place for Emporous collaboration with community members and contributors.
 
-### UOR Client
-The UOR Client libraries and reference CLI are located in the [uor-framework/uor-client-go](https://github.com/uor-framework/uor-client-go) repository. The CLI is the reference implementation of the UOR Client libraries.
+### Emporous Client
+The Emporous Client libraries and reference CLI are located in the [emporous/emporous-go](https://github.com/emporous/emporous-go) repository. The CLI is the reference implementation of the Emporous Client libraries.
 
 ### Getting Started Guide
-If just getting started, be sure to check out the [getting started guide](https://universalreference.io/docs/category/getting-started), a simple walk-through with the UOR Client CLI and introduction to UOR Concepts
+If just getting started, be sure to check out the [getting started guide](https://universalreference.io/docs/category/getting-started), a simple walk-through with the Emporous Client CLI and introduction to Emporous Concepts
 
 ### Join in!
-- [Twitter](https://twitter.com/UorFramework)
-- [CNCF Slack #uor-framework](https://app.slack.com/client/T08PSQ7BQ/C034YMT1P41)
-- [Mailing List](https://groups.google.com/g/uor-framework/)
+- [Twitter](https://twitter.com/Emporous)
+- [CNCF Slack #emporous](https://app.slack.com/client/T08PSQ7BQ/C034YMT1P41)
+- [Mailing List](https://groups.google.com/g/emporous/)
 - [universalreference.io](https://universalreference.io)


### PR DESCRIPTION
Updates content and repository names. Should be merged after this [PR](https://github.com/emporous/.github/pull/18)  in the main organization.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>